### PR TITLE
chore: bump GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/docker-publish-release.yml
+++ b/.github/workflows/docker-publish-release.yml
@@ -16,16 +16,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,16 +18,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/github-release-publish.yml
+++ b/.github/workflows/github-release-publish.yml
@@ -19,12 +19,12 @@ jobs:
         goos: [linux, darwin]
         goarch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '1.20'
-      - uses: wangyoucao577/go-release-action@v1.28
+      - uses: wangyoucao577/go-release-action@v1.55
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '1.20'
 
@@ -35,7 +35,7 @@ jobs:
           tar -C bin -zcf go-ycsb-$GOOS-$GOARCH.tar.gz go-ycsb
 
       - name: Release latest build
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         if: github.event_name == 'push'
         with:
           name: Latest Build


### PR DESCRIPTION
GitHub is deprecating the **node20** runner for GitHub Actions on **June 16, 2026**. Workflow steps using node20-based action versions will fail after this date.

This PR bumps all affected actions to their latest node24-compatible versions.

> Reviewed by 3 independent agents (opus/sonnet/haiku) before opening.